### PR TITLE
Feature: Implementa fluxo de recuperação de senha

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -36,7 +36,7 @@ namespace GoDecola.API.Controllers
             _config = config;
         }
 
-        [HttpGet("forgot-password")]
+        [HttpPost("forgot-password")]
         public async Task<IActionResult> ForgotPassword(ForgotPasswordDTO forgotPassword)
         {
             var user = await _userManager.FindByEmailAsync(forgotPassword.Email);
@@ -52,7 +52,7 @@ namespace GoDecola.API.Controllers
             // codifica o token pra ser usado na URL
             var encodedToken = System.Net.WebUtility.UrlEncode(token);
 
-            var resetUrlBase = _config["AppSettings:ResetPasswordUrlBase"];
+            var resetUrlBase = _config["FrontendSettings:ResetPasswordUrl"];
             if (string.IsNullOrEmpty(resetUrlBase))
             {
                 return StatusCode(500, "A URL de redefinição de senha não está configurada no servidor");

--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -23,13 +23,71 @@ namespace GoDecola.API.Controllers
         private readonly SignInManager<User> _signInManager;
         private readonly JwtService _jwtService;
         private readonly IMapper _mapper;
+        private readonly IEmailService _emailService;
+        private readonly IConfiguration _config;
 
-        public AuthController(UserManager<User> userManager, SignInManager<User> signInManager, JwtService jwtService, IMapper mapper)
+        public AuthController(UserManager<User> userManager, SignInManager<User> signInManager, JwtService jwtService, IMapper mapper, IEmailService emailService, IConfiguration config)
         {
             _userManager = userManager;
             _signInManager = signInManager;
             _jwtService = jwtService; 
             _mapper = mapper;
+            _emailService = emailService;
+            _config = config;
+        }
+
+        [HttpGet("forgot-password")]
+        public async Task<IActionResult> ForgotPassword(ForgotPasswordDTO forgotPassword)
+        {
+            var user = await _userManager.FindByEmailAsync(forgotPassword.Email);
+
+            if (user == null)
+            {
+                return Ok(new { message = "Se o email estiver cadastrado, um link para redefinição de senha será enviado." }); // dessa forma nao revela se o email existe ou nao na base de dados
+            }
+
+            // gera o token de redefinicao de senha, o identity cuida da expiracao (1h por padrao)
+            var token = await _userManager.GeneratePasswordResetTokenAsync(user);
+
+            // codifica o token pra ser usado na URL
+            var encodedToken = System.Net.WebUtility.UrlEncode(token);
+
+            var resetUrlBase = _config["AppSettings:ResetPasswordUrlBase"];
+            if (string.IsNullOrEmpty(resetUrlBase))
+            {
+                return StatusCode(500, "A URL de redefinição de senha não está configurada no servidor");
+            }
+
+            var resetUrl = $"{resetUrlBase}?token={encodedToken}&email={user.Email}";
+
+            await _emailService.SendForgotPasswordEmailAsync(
+                user.Email,
+                user.FirstName,
+                resetUrl
+            );
+
+            return Ok(new { message = "Se o email estiver cadastrado, um link para redefinição de senha será enviado." });
+        }
+
+        [HttpPost("reset-password")]
+        public async Task<IActionResult> ResetPassword(ResetPasswordDTO resetPassword)
+        {
+            var user = await _userManager.FindByEmailAsync(resetPassword.Email);
+            if (user == null)
+            {
+                return BadRequest("Link de redefinição inválido ou expirado");
+            }
+
+            var decodedToken = System.Net.WebUtility.UrlDecode(resetPassword.Token);
+
+            var result = await _userManager.ResetPasswordAsync(user, decodedToken, resetPassword.NewPassword);
+
+            if (!result.Succeeded)
+            {
+                return BadRequest("Não foi possível redefinir a senha. O link pode ter expirado ou ser inválido.");
+            }
+
+            return Ok(new { message = "Senha redefinida com sucesso!" });
         }
 
         [HttpPost("signup")]

--- a/Controllers/ReviewController.cs
+++ b/Controllers/ReviewController.cs
@@ -38,7 +38,7 @@ namespace GoDecola.API.Controllers
                 return NotFound($"Review {reviewId} não encontrada");
             }
 
-            review.Status = statusReview.Status.ToString();
+            review.Status = statusReview.Status;
 
             await _reviewRepository.UpdateAsync(review);
 
@@ -100,7 +100,7 @@ namespace GoDecola.API.Controllers
             var review = _mapper.Map<Review>(createReview);
             review.UserId = userId;
             review.ReviewDate = DateTime.UtcNow;
-            review.Status = ReviewStatus.PENDING.ToString();
+            review.Status = ReviewStatus.PENDING;
 
             var newReview = await _reviewRepository.AddAsync(review);
             var reviewDto = _mapper.Map<ReviewDTO>(newReview);

--- a/DTOs/UserDTOs/ForgotPasswordDTO.cs
+++ b/DTOs/UserDTOs/ForgotPasswordDTO.cs
@@ -1,0 +1,7 @@
+﻿namespace GoDecola.API.DTOs.UserDTOs
+{
+    public class ForgotPasswordDTO
+    {
+        public string Email { get; set; }
+    }
+}

--- a/DTOs/UserDTOs/ResetPasswordDTO.cs
+++ b/DTOs/UserDTOs/ResetPasswordDTO.cs
@@ -1,0 +1,9 @@
+﻿namespace GoDecola.API.DTOs.UserDTOs
+{
+    public class ResetPasswordDTO
+    {
+        public string Email { get; set; }
+        public string Token { get; set; }
+        public string NewPassword { get; set; }
+    }
+}

--- a/Entities/Review.cs
+++ b/Entities/Review.cs
@@ -1,4 +1,6 @@
-﻿namespace GoDecola.API.Entities
+﻿using GoDecola.API.Enums;
+
+namespace GoDecola.API.Entities
 {
     public class Review
     {

--- a/Enums/ReviewStatus.cs
+++ b/Enums/ReviewStatus.cs
@@ -1,0 +1,9 @@
+﻿namespace GoDecola.API.Enums
+{
+    public enum ReviewStatus
+    {
+        PENDING, 
+        APPROVED,
+        REJECTED
+    }
+}

--- a/GoDecola.API.csproj
+++ b/GoDecola.API.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
+    <PackageReference Include="MailKit" Version="4.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.1" />

--- a/Program.cs
+++ b/Program.cs
@@ -81,7 +81,7 @@ builder.Services.AddScoped<IReservationRepository, ReservationRepository>();
 builder.Services.AddScoped<IMediaService, MediaService>();
 builder.Services.AddScoped<IReviewRepository, ReviewRepository>();
 builder.Services.AddScoped<IWishlistRepository, WishlistRepository>();
-
+builder.Services.AddScoped<IEmailService, EmailService>();
 
 builder.Services.AddScoped<IPaymentService>(provider =>
 {

--- a/Services/EmailService.cs
+++ b/Services/EmailService.cs
@@ -32,8 +32,20 @@ namespace GoDecola.API.Services
             };
 
             using var smtp = new SmtpClient();
-            await smtp.ConnectAsync(_config["EmailSettings:SmptServer"], int.Parse(_config["EmailSettings:Port"]), SecureSocketOptions.StartTls);
-            await smtp.AuthenticateAsync(_config["EmailSettings:Username"], _config["EmailSettings:Password"]);
+            int port = int.Parse(_config["EmailSettings:Port"]);
+
+            if (_config["EmailSettings:SmtpServer"] == "localhost")
+            {
+                // conecta sem seguranca para o smtp4dev
+                await smtp.ConnectAsync(_config["EmailSettings:SmtpServer"], port, SecureSocketOptions.None);
+            }
+            else
+            {
+                // conecta com TlS para servidores de producao
+                await smtp.ConnectAsync(_config["EmailSettings:SmtpServer"], port, SecureSocketOptions.StartTls);
+                await smtp.AuthenticateAsync(_config["EmailSettings:Username"], _config["EmailSettings:Password"]);
+            }
+
             await smtp.SendAsync(email);
             await smtp.DisconnectAsync(true);
         }

--- a/Services/EmailService.cs
+++ b/Services/EmailService.cs
@@ -1,0 +1,41 @@
+﻿using MailKit.Net.Smtp;
+using MailKit.Security;
+using MimeKit;
+using MimeKit.Text;
+
+namespace GoDecola.API.Services
+{
+    public class EmailService : IEmailService
+    {
+        private readonly IConfiguration _config;
+
+        public EmailService(IConfiguration config)
+        {
+            _config = config;
+        }
+
+        public async Task SendForgotPasswordEmailAsync(string toEmail, string userName, string resetLink)
+        {
+            var email = new MimeMessage();
+            email.From.Add(MailboxAddress.Parse(_config["EmailSettings:From"]));
+            email.To.Add(MailboxAddress.Parse(toEmail));
+            email.Subject = "GoDecola - Redefinição de Senha";
+
+            string emailTemplate = await File.ReadAllTextAsync("Templates/ForgotPasswordEmail.html");
+            string emailBody = emailTemplate
+                .Replace("{UserName}", userName)
+                .Replace("{ResetLink}", resetLink);
+
+            email.Body = new TextPart(TextFormat.Html)
+            {
+                Text = emailBody
+            };
+
+            using var smtp = new SmtpClient();
+            await smtp.ConnectAsync(_config["EmailSettings:SmptServer"], int.Parse(_config["EmailSettings:Port"]), SecureSocketOptions.StartTls);
+            await smtp.AuthenticateAsync(_config["EmailSettings:Username"], _config["EmailSettings:Password"]);
+            await smtp.SendAsync(email);
+            await smtp.DisconnectAsync(true);
+        }
+    }
+}

--- a/Services/IEmailService.cs
+++ b/Services/IEmailService.cs
@@ -1,0 +1,7 @@
+﻿namespace GoDecola.API.Services
+{
+    public interface IEmailService
+    {
+        Task SendForgotPasswordEmailAsync(string toEmail, string userName, string resetLink);
+    }
+}

--- a/Templates/ForgotPasswordEmail.html
+++ b/Templates/ForgotPasswordEmail.html
@@ -1,0 +1,23 @@
+﻿<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Redefinição de Senha</title>
+</head>
+<body style="font-family: Arial, sans-serif; text-align: center; color: #333;">
+
+    <div style="width: 80%; margin: 20px auto; border: 1px solid #ddd; padding: 20px;">
+        <h2>Olá, {UserName}!</h2>
+        <p>Recebemos uma solicitação para redefinir a senha da sua conta na GoDecola.</p>
+        <p>Clique no botão abaixo para criar uma nova senha:</p>
+        <a href="{ResetLink}" style="background-color: #007bff; color: white; padding: 15px 25px; text-decoration: none; border-radius: 5px; display: inline-block; margin: 20px 0;">
+            Redefinir Minha Senha
+        </a>
+        <p>Este link irá expirar em 1 hora.</p>
+        <p>Se você não solicitou uma redefinição de senha, por favor, ignore este e-mail.</p>
+        <hr>
+        <p style="font-size: 0.8em; color: #777;">Equipe GoDecola</p>
+    </div>
+
+</body>
+</html>

--- a/appsettings.json
+++ b/appsettings.json
@@ -21,10 +21,10 @@
   },
   "EmailSettings": {
     "From": "noreply@godecola.com",
-    "SmtpServer": "smtp.smtp4dev.com",
-    "Port": "587",
-    "Username": "your-email-username",
-    "Password": "your-email-password"
+    "SmtpServer": "localhost",
+    "Port": "25",
+    "Username": "",
+    "Password": ""
   },
 
   "FrontendSettings": {

--- a/appsettings.json
+++ b/appsettings.json
@@ -18,6 +18,16 @@
     "SuccessUrl": "http://localhost:5071/api/payment/success",
     "CancelUrl": "http://localhost:5071/api/payment/cancel",
     "WebhookSecret": "whsec_ec42dd5560ab8215f40391c58d979d345f0b35a76b64b9920a330a8bdbf67808"
-  }
+  },
+  "EmailSettings": {
+    "From": "noreply@godecola.com",
+    "SmtpServer": "smtp.smtp4dev.com",
+    "Port": "587",
+    "Username": "your-email-username",
+    "Password": "your-email-password"
+  },
 
+  "FrontendSettings": {
+    "ResetPasswordUrl": "http://localhost:5173/reset-password"
+  }
 }


### PR DESCRIPTION
Implementa a funcionalidade completa de backend para recuperação de senha de usuários. O fluxo permite que um usuário solicite um link de redefinição por e-mail, que expira após um período configurável (padrão do `UserIdentity`: 1h).

### O que foi feito:
- [x] **Endpoint `POST /auth/forgot-password`:**
  - Recebe o e-mail do usuário e valida sua existência.
  - Gera um token de redefinição seguro via `UserManager`.
  - Envia um e-mail para o usuário com o link para a redefinição.
- [x] **Endpoint `POST /auth/reset-password`:**
  - Recebe o token, e-mail e a nova senha.
  - Valida o token e sua expiração.
  - Atualiza a senha do usuário de forma criptografada.
  - Invalida o token após o uso.
- [x] **Serviço de E-mail (`EmailService`):**
  - Implementado com `MailKit` e configurado para usar `smtp4dev` em ambiente de desenvolvimento.
- [x] **Templates de E-mail:**
  - Criado template HTML para o e-mail de recuperação.

### Como Testar:

1.  Inicie a API e o `smtp4dev`.
2.  Use o Swagger para fazer uma chamada a `POST /api/auth/forgot-password` com um e-mail de usuário existente.
3.  Verifique a chegada do e-mail na interface do `smtp4dev` (`http://localhost:5000`).
4.  Copie o token da URL no e-mail.
5.  Use o Swagger para fazer uma chamada a `POST /api/auth/reset-password` com o e-mail, o token e uma nova senha.
6.  Verifique se a resposta é de sucesso.
7.  Tente fazer login com a nova senha.

### O Email deve chegar assim no `smtp4dev`:

<img width="1919" height="741" alt="image" src="https://github.com/user-attachments/assets/575d28f5-1121-483c-a5c3-c77f7b687d7e" />

